### PR TITLE
Add missing null check of file names. #8

### DIFF
--- a/app/code/community/Fooman/Speedster/Block/Page/Html/Head.php
+++ b/app/code/community/Fooman/Speedster/Block/Page/Html/Head.php
@@ -46,6 +46,9 @@ class Fooman_Speedster_Block_Page_Html_Head extends Mage_Page_Block_Html_Head
         $alternate = '<link rel="alternate" type="%s" href="%s" %s />';
 
         foreach ($this->_data['items'] as $item) {
+            if (is_null($item['name'])) {
+                continue;
+            }
             if (!is_null($item['cond']) && !$this->getData($item['cond'])) {
                 continue;
             }


### PR DESCRIPTION
Not sure where the error comes from but on a few pages the js/ folder itself gets processed by 
Fooman_Speedster_Block_Page_Html_Head which leads to errors as described in #8.

This PR adds a simple null check for $item['name'] to prevent frontend errors.