### PR TITLE
Strict standards

### DIFF
--- a/app/code/community/Fooman/Speedster/Model/Selftester.php
+++ b/app/code/community/Fooman/Speedster/Model/Selftester.php
@@ -15,7 +15,7 @@ class Fooman_Speedster_Model_Selftester extends Fooman_Common_Model_Selftester
 
     const MANUAL_URL = 'http://cdn.fooman.co.nz/media/custom/upload/InstructionsandTroubleshooting-FoomanSpeedster.pdf';
 
-    public function main()
+    public function main($fix = false)
     {
         $this->_checkModuleOutput();
         $this->_checkPermissions();


### PR DESCRIPTION
A minor change to fix strict standards error message:

An error occurred while saving this configuration: Strict Notice: Declaration of Fooman_Speedster_Model_Selftester::main() should be compatible with Fooman_Common_Model_Selftester::main($fix = false) in [...]/vendor/fooman/speedster/app/code/community/Fooman/Speedster/Model/Selftester.php on line 14

This replaces https://github.com/fooman/speedster/pull/12