### PR TITLE
The Content-Length header is not returned in certain instances. 

### DIFF
--- a/app/code/community/Fooman/Speedster/Block/Page/Html/Head.php
+++ b/app/code/community/Fooman/Speedster/Block/Page/Html/Head.php
@@ -201,7 +201,7 @@ class Fooman_Speedster_Block_Page_Html_Head extends Mage_Page_Block_Html_Head
         return $html;
     }
 
-    public function getChunkedItems($items, $prefix = '', $maxLen = 2000)
+    public function getChunkedItems($items, $prefix = '', $maxLen = 1000)
     {
         if (!Mage::getStoreConfigFlag('foomanspeedster/settings/enabled')) {
             return parent::getChunkedItems($items, $prefix, 450);

--- a/app/code/community/Fooman/Speedster/Model/Selftester.php
+++ b/app/code/community/Fooman/Speedster/Model/Selftester.php
@@ -188,13 +188,13 @@ class Fooman_Speedster_Model_Selftester extends Fooman_Common_Model_Selftester
             /* eof fix */
 
             $response = $client->request();
-            $originalLength = $response->getHeader('Content-Length');
+            $originalLength = strlen($response->getRawBody());;
 
             $url = Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_WEB) . 'lib/minify/m.php?f=/skin/frontend/default' .
                 '/default/css/print.css';
             $client->setUri($url);
             $response = $client->request();
-            $minifiedLength = $response->getHeader('Content-Length');
+            $minifiedLength = strlen($response->getRawBody());;
 
 
             if ($minifiedLength >= $originalLength) {
@@ -261,7 +261,7 @@ class Fooman_Speedster_Model_Selftester extends Fooman_Common_Model_Selftester
             /* eof fix */
 
             $response = $client->request();
-            $originalLength = $response->getHeader('Content-Length');
+            $originalLength = strlen($response->getRawBody());;
 
             $moduleVersion = (string)Mage::getConfig()->getNode()->modules->Fooman_Speedster->version;
 
@@ -277,7 +277,7 @@ class Fooman_Speedster_Model_Selftester extends Fooman_Common_Model_Selftester
 
             $client->setUri($url);
             $response = $client->request();
-            $minifiedLength = $response->getHeader('Content-Length');
+            $minifiedLength = strlen($response->getRawBody());;
 
             if ($minifiedLength >= $originalLength) {
                 $this->messages[]


### PR DESCRIPTION
I believe this is an Apache behaviour when gzip compression is enabled (http://serverfault.com/questions/183843/content-length-not-sent-when-gzip-compression-enabled-in-apache).

I could also be a Cloudflare behaviour. 

Regardless, this causes the self test to fail.
